### PR TITLE
Fix map_item_metadata sorting

### DIFF
--- a/torchrecsys/dataset/dataset.py
+++ b/torchrecsys/dataset/dataset.py
@@ -100,7 +100,13 @@ class Data:
 
         grouping_col = [self.item_id] + self.metadata_id
 
-        data = self.dataset.groupby(grouping_col, as_index=False).agg({self.user_id: 'count'}).sort_values('product_code')
+        # Sort by the item identifier to keep items in a consistent order
+        data = (
+            self.dataset
+            .groupby(grouping_col, as_index=False)
+            .agg({self.user_id: 'count'})
+            .sort_values(self.item_id)
+        )
 
         dummies = None
         for metadata in grouping_col:


### PR DESCRIPTION
## Summary
- sort by `self.item_id` in `map_item_metadata`

## Testing
- `pytest -q` *(fails: NameError in mlp.py)*

------
https://chatgpt.com/codex/tasks/task_e_68414d11e424832a9362e96df3537067